### PR TITLE
Pass along extra arguments in ReleaseExists

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -191,13 +191,13 @@ func PluginInstalled(plugin string) (bool, error) {
 	return false, nil
 }
 
-func ReleaseExists(namespace string, release string) bool {
+func ReleaseExists(namespace string, release string, args ...string) bool {
 	var exists = true
 	var err error
 	var res Result
 
 	// Get the status of the release for the namespace
-	res, err = RunHelmCommand("status", release, "--namespace", namespace)
+	res, err = RunHelmCommand("status", release, "--namespace", namespace, args...)
 	if err != nil {
 		if res.Stderr != "Error: release: not found" {
 			exists = false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,9 +195,16 @@ func ReleaseExists(namespace string, release string, args ...string) bool {
 	var exists = true
 	var err error
 	var res Result
+	var cmdArgs []string
+
+	cmdArgs = append(cmdArgs, "status")
+	cmdArgs = append(cmdArgs, release)
+	cmdArgs = append(cmdArgs, "--namespace")
+	cmdArgs = append(cmdArgs, namespace)
+	cmdArgs = append(cmdArgs, args...)
 
 	// Get the status of the release for the namespace
-	res, err = RunHelmCommand("status", release, "--namespace", namespace, args...)
+	res, err = RunHelmCommand(cmdArgs...)
 	if err != nil {
 		if res.Stderr != "Error: release: not found" {
 			exists = false

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -122,7 +122,7 @@ func syncCharts(charts []config.ChartConfig, args ...string) error {
 		} else {
 
 			// If the release does not exist do not attempt to delete the release
-			exists := ReleaseExists(chart.Namespace, chart.Release)
+			exists := ReleaseExists(chart.Namespace, chart.Release, args...)
 			if !exists {
 				log.Infof("Skipping '%s/%s' as the release does not exist.", chart.Namespace, chart.Release)
 				continue


### PR DESCRIPTION
in Jenkins we are passing `--kubeconfig` argument to helm commands using `binnacle <cmd> -- --kubeconfig <cfg>`. For most commands, these arguments get forwarded to helm. In this case they were not, so the release existence check was not respecting the kubeconfig and in some cases was running against the wrong cluster.